### PR TITLE
refactor(datepicker): simplify weekStart prop and update theme colors

### DIFF
--- a/packages/ui-components-react/src/datepicker/datepickerProps.ts
+++ b/packages/ui-components-react/src/datepicker/datepickerProps.ts
@@ -3,10 +3,9 @@
 import type { DatepickerProps as FlowbiteDatepickerProps } from "flowbite-react";
 import PropTypes, { type InferProps } from "prop-types";
 import type { PropsWithChildren } from "react";
-import { DatepickerDays } from "./datepickerDays";
 
 export const DatepickerPropTypes = {
-	weekStart: PropTypes.oneOf(Object.values(DatepickerDays)),
+	weekStart: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6]),
 	localization: PropTypes.shape({
 		language: PropTypes.string,
 		labelTodayButton: PropTypes.string,

--- a/packages/ui-components-react/src/datepicker/datepickerTheme.json
+++ b/packages/ui-components-react/src/datepicker/datepickerTheme.json
@@ -25,7 +25,7 @@
 			"base": "mt-2 flex space-x-2",
 			"button": {
 				"base": "w-full rounded-lg px-5 py-2 text-center text-sm font-medium focus:ring-4 focus:ring-cyan-300",
-				"today": "bg-surface-button text-white hover:bg-surface-button-700 dark:bg-surface-button dark:hover:bg-surface-button-700",
+				"today": "bg-surface-button-alt text-white hover:bg-surface-button-alt-hover dark:bg-surface-button dark:hover:bg-surface-button-700",
 				"clear": "border border-gray-300 bg-white text-gray-900 hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600"
 			}
 		}
@@ -40,7 +40,7 @@
 				"base": "grid w-64 grid-cols-7",
 				"item": {
 					"base": "block flex-1 cursor-pointer rounded-lg border-0 text-center text-sm font-semibold leading-9 text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-600",
-					"selected": "bg-surface-button text-white hover:bg-surface-button",
+					"selected": "bg-surface-button text-white hover:bg-surface-button-700",
 					"disabled": "text-gray-500"
 				}
 			}

--- a/packages/ui-components-react/src/datepicker/datepickerTheme.json
+++ b/packages/ui-components-react/src/datepicker/datepickerTheme.json
@@ -24,8 +24,8 @@
 		"footer": {
 			"base": "mt-2 flex space-x-2",
 			"button": {
-				"base": "w-full rounded-lg px-5 py-2 text-center text-sm font-medium focus:ring-4 focus:ring-cyan-300",
-				"today": "bg-surface-button-alt text-white hover:bg-surface-button-alt-hover dark:bg-surface-button dark:hover:bg-surface-button-700",
+				"base": "w-full rounded-lg px-5 py-2 text-center text-sm font-medium focus:ring-2",
+				"today": "bg-surface-button-alt text-white hover:enabled:bg-surface-button-alt-hover dark:bg-surface-button dark:hover:bg-surface-button-700 focus:ring-surface-button-alt-pressed",
 				"clear": "border border-gray-300 bg-white text-gray-900 hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600"
 			}
 		}


### PR DESCRIPTION
## Changes

This PR improves the Datepicker component in two main areas:

### Type Safety
- Simplified weekStart prop to use direct numeric values (0-6) and fixed a TS error in the storybook file
- Removed dependency on DatepickerDays enum for better type inference
- Improved alignment with Flowbite's implementation

### Visual Consistency
- Updated selected date color to use surface-button with hover state
- Changed today button to use surface-button-alt with hover state
- Added proper hover states for better user interaction

## Testing
- All existing Datepicker stories work as expected
- Type checking is maintained
- Visual appearance is consistent with the design system