### PR TITLE
refactor(footer): simplify FooterProps to only use container prop from Flowbite

### DIFF
--- a/packages/ui-components-react/src/footer/footerProps.ts
+++ b/packages/ui-components-react/src/footer/footerProps.ts
@@ -12,5 +12,5 @@ export const FooterPropTypes = {
  * Footer props.
  */
 export type FooterProps = PropsWithChildren<
-	InferProps<typeof FooterPropTypes> & Omit<FlowbiteFooterProps, "color" | "label">
+	InferProps<typeof FooterPropTypes> & Pick<FlowbiteFooterProps, "container">
 >;


### PR DESCRIPTION
- Replace Omit with Pick to explicitly include only the container prop from FlowbiteFooterProps
- This change makes the component's external API more precise and maintainable
- Removes unnecessary props that weren't being used in the implementation