### PR TITLE
refactor(listGroup): make component more flexible, simplify props and improve type safety

### DIFF
--- a/apps/ui-storybook-react/src/stories/ListGroup.stories.ts
+++ b/apps/ui-storybook-react/src/stories/ListGroup.stories.ts
@@ -12,7 +12,8 @@ const meta = {
 			{ title: "Item 1", icon: IconsSolid.User },
 			{ title: "Item 2", icon: IconsSolid.Database, active: true },
 			{ title: "Item 3", disabled: true },
-			{ title: "Item 4" }
+			{ title: "Item 4" },
+			{ title: "Item 5", href: "#" }
 		]
 	}
 } satisfies Meta<typeof ListGroup>;

--- a/packages/ui-components-react/src/listGroup/listGroup.tsx
+++ b/packages/ui-components-react/src/listGroup/listGroup.tsx
@@ -32,25 +32,22 @@ export class ListGroup extends React.Component<ListGroupProps> {
 	 * @returns The component to render.
 	 */
 	public render(): ReactNode {
-		const { items } = this._props;
+		const { items, className } = this._props;
+
 		return (
-			<div className="flex justify-center">
-				<FlowbiteListGroup className="w-48">
-					{items && items?.length > 0 ? (
-						items.map(item => (
-							<FlowbiteListGroup.Item
-								icon={item?.icon ?? undefined}
-								disabled={item?.disabled ?? false}
-								active={item?.active ?? false}
-							>
-								{item?.title}
-							</FlowbiteListGroup.Item>
-						))
-					) : (
-						<></>
-					)}
-				</FlowbiteListGroup>
-			</div>
+			<FlowbiteListGroup className={className}>
+				{items.map((item, index) => (
+					<FlowbiteListGroup.Item
+						key={`${item.title}-${index}`}
+						icon={item.icon}
+						disabled={item.disabled}
+						active={item.active}
+						href={item.href}
+					>
+						{item.title}
+					</FlowbiteListGroup.Item>
+				))}
+			</FlowbiteListGroup>
 		);
 	}
 }

--- a/packages/ui-components-react/src/listGroup/listGroupProps.ts
+++ b/packages/ui-components-react/src/listGroup/listGroupProps.ts
@@ -1,8 +1,7 @@
 // Copyright 2024 IOTA Stiftung.
 // SPDX-License-Identifier: Apache-2.0.
-import type { ListGroupProps as FlowbiteListGroupProps } from "flowbite-react";
-import PropTypes, { type InferProps } from "prop-types";
-import type { PropsWithChildren } from "react";
+import PropTypes from "prop-types";
+import type { FC, SVGProps } from "react";
 
 export const ListGroupPropTypes = {
 	items: PropTypes.arrayOf(
@@ -10,14 +9,49 @@ export const ListGroupPropTypes = {
 			title: PropTypes.string.isRequired,
 			icon: PropTypes.func,
 			active: PropTypes.bool,
-			disabled: PropTypes.bool
+			disabled: PropTypes.bool,
+			href: PropTypes.string
 		})
-	)
+	).isRequired,
+	className: PropTypes.string
 };
 
 /**
- * ListGroup props.
+ * Props for a single list group item
  */
-export type ListGroupProps = PropsWithChildren<
-	InferProps<typeof ListGroupPropTypes> & Omit<FlowbiteListGroupProps, "color" | "label">
->;
+export interface ListGroupItem {
+	/**
+	 * The title text of the list item
+	 */
+	title: string;
+	/**
+	 * Optional icon component to display
+	 */
+	icon?: FC<SVGProps<SVGSVGElement>>;
+	/**
+	 * Whether the item is active
+	 */
+	active?: boolean;
+	/**
+	 * Whether the item is disabled
+	 */
+	disabled?: boolean;
+	/**
+	 * Optional href for the item
+	 */
+	href?: string;
+}
+
+/**
+ * Props for the ListGroup component
+ */
+export interface ListGroupProps {
+	/**
+	 * Array of list items to display
+	 */
+	items: ListGroupItem[];
+	/**
+	 * Additional CSS classes
+	 */
+	className?: string;
+}


### PR DESCRIPTION
This PR refactors the ListGroup component to make it more flexible and type-safe while following React best practices.

### Changes

#### Component Improvements
- Remove hardcoded styles to make the component more flexible
- Add proper `key` prop to mapped items to fix React warnings
- Add `href` support to list items for better navigation options
- Make component styling configurable via `className` prop

#### Type Safety & Props
- Remove unnecessary Flowbite type inheritance for cleaner types
- Update icon type to be more specific (`FC<SVGProps<SVGSVGElement>>`)
- Make component props more explicit and self-documenting
- Remove unnecessary optional chaining

#### Documentation
- Add `href` example in stories
- Improve props documentation
- Add proper JSDoc comments

### Testing
The component has been tested in Storybook with various configurations including:
- Items with icons
- Active/disabled states
- Items with href links
- Custom styling via className