### PR TITLE
refactor(modal): improve type definitions and component behavior

### DIFF
--- a/apps/ui-storybook-react/src/stories/Modal.stories.ts
+++ b/apps/ui-storybook-react/src/stories/Modal.stories.ts
@@ -23,10 +23,14 @@ const meta = {
 		popup: {
 			options: Object.values([true, false]),
 			control: { type: "inline-radio" }
+		},
+		initialFocus: {
+			control: false
 		}
 	},
 	args: {
-		body: "Modal Body"
+		body: "Modal Body",
+		show: true
 	}
 } satisfies Meta<typeof Modal>;
 

--- a/packages/ui-components-react/src/modal/modal.tsx
+++ b/packages/ui-components-react/src/modal/modal.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0.
 import { Modal as FlowbiteModal, Button as FlowbiteButton } from "flowbite-react";
 import React, { type ReactNode } from "react";
-import { ModalPropTypes, type ModalProps } from "./modalProps";
+import { ModalPropTypes, ModalDefaultProps, type ModalProps } from "./modalProps";
 
 /**
  * Modal component.
@@ -12,6 +12,11 @@ export class Modal extends React.Component<ModalProps> {
 	 * The prop types of the component.
 	 */
 	public static propTypes = ModalPropTypes;
+
+	/**
+	 * The default props of the component.
+	 */
+	public static defaultProps = ModalDefaultProps;
 
 	/**
 	 * The props of the component.
@@ -32,9 +37,9 @@ export class Modal extends React.Component<ModalProps> {
 	 * @returns The component to render.
 	 */
 	public render(): ReactNode {
-		const { header, body, footerButtons, ...rest } = this._props;
+		const { header, body, footerButtons, show = false, onClose, ...rest } = this._props;
 		return (
-			<FlowbiteModal {...rest} show={true}>
+			<FlowbiteModal {...rest} show={show} onClose={onClose}>
 				{header && <FlowbiteModal.Header>{header}</FlowbiteModal.Header>}
 
 				{body && <FlowbiteModal.Body>{body}</FlowbiteModal.Body>}
@@ -42,8 +47,9 @@ export class Modal extends React.Component<ModalProps> {
 				{footerButtons && (
 					<FlowbiteModal.Footer>
 						{footerButtons && footerButtons?.length > 0 ? (
-							footerButtons.map(button => (
+							footerButtons.map((button, index) => (
 								<FlowbiteButton
+									key={`modal-button-${index}`}
 									className={button?.className ?? ""}
 									onClick={button?.onClick ?? undefined}
 								>

--- a/packages/ui-components-react/src/modal/modalProps.ts
+++ b/packages/ui-components-react/src/modal/modalProps.ts
@@ -1,17 +1,50 @@
 // Copyright 2024 IOTA Stiftung.
 // SPDX-License-Identifier: Apache-2.0.
 import type { ModalProps as FlowbiteModalProps } from "flowbite-react";
-import PropTypes, { type InferProps } from "prop-types";
-import type { PropsWithChildren } from "react";
+import PropTypes from "prop-types";
+import type { RefObject, ReactNode } from "react";
 import { ModalPositions } from "./modalPositions";
 import { ModalSizes } from "./modalSizes";
+
+/**
+ *
+ */
+export interface FooterButton {
+	/**
+	 *
+	 */
+	label: string;
+	/**
+	 *
+	 */
+	className?: string;
+	/**
+	 *
+	 */
+	onClick?: () => void;
+}
+
+export const ModalDefaultProps = {
+	show: false,
+	dismissible: true,
+	popup: false,
+	position: ModalPositions.Center,
+	size: ModalSizes.Medium
+};
 
 export const ModalPropTypes = {
 	position: PropTypes.oneOf(Object.values(ModalPositions)),
 	size: PropTypes.oneOf(Object.values(ModalSizes)),
 	dismissible: PropTypes.bool,
 	popup: PropTypes.bool,
-	initialFocus: PropTypes.bool,
+	initialFocus: PropTypes.oneOfType([
+		PropTypes.number,
+		PropTypes.shape({
+			current: PropTypes.instanceOf(Element)
+		})
+	]),
+	show: PropTypes.bool,
+	onClose: PropTypes.func,
 	header: PropTypes.node,
 	body: PropTypes.node,
 	footerButtons: PropTypes.arrayOf(
@@ -26,6 +59,52 @@ export const ModalPropTypes = {
 /**
  * Modal props.
  */
-export type ModalProps = PropsWithChildren<
-	InferProps<typeof ModalPropTypes> & Omit<FlowbiteModalProps, "color" | "label">
->;
+export interface ModalProps extends Pick<FlowbiteModalProps, "theme" | "className" | "root"> {
+	/**
+	 * Position of the modal
+	 */
+	position?: ModalPositions;
+	/**
+	 * Size of the modal
+	 */
+	size?: ModalSizes;
+	/**
+	 * Whether the modal can be dismissed
+	 * @default true
+	 */
+	dismissible?: boolean;
+	/**
+	 * Whether the modal is in popup style
+	 * @default false
+	 */
+	popup?: boolean;
+	/**
+	 * Initial focus element
+	 */
+	initialFocus?: number | RefObject<HTMLElement>;
+	/**
+	 * Whether the modal is visible
+	 * @default false
+	 */
+	show?: boolean;
+	/**
+	 * Callback when modal is closed
+	 */
+	onClose?: () => void;
+	/**
+	 * Modal header content
+	 */
+	header?: ReactNode;
+	/**
+	 * Modal body content
+	 */
+	body?: ReactNode;
+	/**
+	 * Footer buttons configuration
+	 */
+	footerButtons?: FooterButton[];
+	/**
+	 * Children content
+	 */
+	children?: ReactNode;
+}


### PR DESCRIPTION
This PR improves the Modal component by refactoring its type definitions and enhancing its behavior.

Changes:
- Replace deprecated `MutableRefObject` with `RefObject` for `initialFocus` prop
- Switch to explicit interface definition for better type safety and documentation
- Add proper JSDoc comments for all props
- Fix modal visibility control by properly handling `show` and `onClose` props
- Add key prop to footer buttons to prevent React warnings
- Add default props for better component predictability
- Update Storybook configuration to better handle `initialFocus` and `show` props
