### PR TITLE
feat(ui): enhance Progress component with custom colors and centered text

### DIFF
--- a/apps/ui-storybook-react/src/stories/Progress.stories.ts
+++ b/apps/ui-storybook-react/src/stories/Progress.stories.ts
@@ -1,7 +1,12 @@
 // Copyright 2024 IOTA Stiftung.
 // SPDX-License-Identifier: Apache-2.0.
 import type { Meta, StoryObj } from "@storybook/react";
-import { Progress, ProgressPositions, ProgressSizes } from "@twin.org/ui-components-react";
+import {
+	Progress,
+	ProgressPositions,
+	ProgressSizes,
+	ProgressColors
+} from "@twin.org/ui-components-react";
 
 const meta = {
 	title: "Components/Progress",
@@ -18,6 +23,10 @@ const meta = {
 		size: {
 			options: Object.values(ProgressSizes),
 			control: { type: "inline-radio" }
+		},
+		color: {
+			options: Object.values(ProgressColors),
+			control: { type: "select" }
 		},
 		labelProgress: {
 			options: Object.values([true, false]),

--- a/packages/ui-components-react/src/index.tsx
+++ b/packages/ui-components-react/src/index.tsx
@@ -66,6 +66,7 @@ export * from "./progress/progress";
 export * from "./progress/progressProps";
 export * from "./progress/progressPositions";
 export * from "./progress/progressSizes";
+export * from "./progress/progressColors";
 export * from "./radio/radio";
 export * from "./radio/radioProps";
 export * from "./rangeSlider/rangeSlider";

--- a/packages/ui-components-react/src/progress/progress.tsx
+++ b/packages/ui-components-react/src/progress/progress.tsx
@@ -1,8 +1,23 @@
 // Copyright 2024 IOTA Stiftung.
 // SPDX-License-Identifier: Apache-2.0.
-import { Progress as FlowbiteProgress } from "flowbite-react";
+import { Progress as FlowbiteProgress, type CustomFlowbiteTheme } from "flowbite-react";
 import React, { type ReactNode } from "react";
 import { ProgressPropTypes, type ProgressProps } from "./progressProps";
+
+const customTheme: CustomFlowbiteTheme["progress"] = {
+	bar: "flex items-center justify-center space-x-2 rounded-full text-center font-medium leading-none text-cyan-300 dark:text-cyan-100",
+	color: {
+		orange: "bg-brand-primary dark:bg-brand-primary",
+		primary: "bg-surface-brand-secondary-1 dark:bg-surface-brand-secondary-1",
+		green: "bg-success dark:bg-success",
+		yellow: "bg-warning dark:bg-warning",
+		pink: "bg-error dark:bg-error",
+		purple: "bg-purple-600 dark:bg-purple-600",
+		indigo: "bg-indigo-600 dark:bg-indigo-600",
+		dark: "bg-primary dark:bg-primary",
+		blue: "bg-information dark:bg-information"
+	}
+};
 
 /**
  * Progress component.
@@ -33,6 +48,6 @@ export class Progress extends React.Component<ProgressProps> {
 	 */
 	public render(): ReactNode {
 		const { ...rest } = this._props;
-		return <FlowbiteProgress {...rest} />;
+		return <FlowbiteProgress theme={customTheme} {...rest} />;
 	}
 }

--- a/packages/ui-components-react/src/progress/progressColors.ts
+++ b/packages/ui-components-react/src/progress/progressColors.ts
@@ -1,0 +1,58 @@
+// Copyright 2024 IOTA Stiftung.
+// SPDX-License-Identifier: Apache-2.0.
+
+/**
+ * Progress colors.
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const ProgressColors = {
+	/**
+	 * Orange.
+	 */
+	Orange: "orange",
+
+	/**
+	 * Primary.
+	 */
+	Primary: "primary",
+
+	/**
+	 * Green.
+	 */
+	Green: "green",
+
+	/**
+	 * Purple.
+	 */
+	Purple: "purple",
+
+	/**
+	 * Yellow.
+	 */
+	Yellow: "yellow",
+
+	/**
+	 * Pink.
+	 */
+	Pink: "pink",
+
+	/**
+	 * Indigo.
+	 */
+	Indigo: "indigo",
+
+	/**
+	 * Dark.
+	 */
+	Dark: "dark",
+
+	/**
+	 * Blue.
+	 */
+	Blue: "blue"
+} as const;
+
+/**
+ * Progress colors.
+ */
+export type ProgressColors = typeof ProgressColors[keyof typeof ProgressColors];

--- a/packages/ui-components-react/src/progress/progressProps.ts
+++ b/packages/ui-components-react/src/progress/progressProps.ts
@@ -3,6 +3,7 @@
 import type { ProgressProps as FlowbiteProgressProps } from "flowbite-react";
 import PropTypes, { type InferProps } from "prop-types";
 import type { PropsWithChildren } from "react";
+import { ProgressColors } from "./progressColors";
 import { ProgressPositions } from "./progressPositions";
 import { ProgressSizes } from "./progressSizes";
 
@@ -13,7 +14,7 @@ export const ProgressPropTypes = {
 	labelProgress: PropTypes.bool,
 	labelText: PropTypes.bool,
 	textLabel: PropTypes.string,
-	color: PropTypes.string,
+	color: PropTypes.oneOf(Object.values(ProgressColors)),
 	progress: PropTypes.number.isRequired
 };
 


### PR DESCRIPTION
## Changes
- Added new [ProgressColors](cci:2://file:///Users/albertolive/Repos/iota/ui/packages/ui-components-react/src/progress/progressColors.ts:57:0-57:80) enum to define available color options
- Updated Progress component theme to use brand-specific color classes:
  - `brand-primary`
  - `success`
  - `warning`
  - `error`
  - `information`
  - And more custom colors
- Centered the percentage text within the progress bar using Flexbox
- Added proper TypeScript exports for the new color types
- Updated Storybook controls to allow color selection

## Testing
The changes can be tested in Storybook by:
1. Viewing the Progress component
2. Using the color selector to try different colors
3. Verifying that the percentage text is properly centered
4. Checking that all colors match the design system

## Screenshots
[Add screenshots showing different color variations of the Progress component]