### PR TITLE
refactor(tooltip): replace FlowbiteButton with custom Button component

### DIFF
--- a/packages/ui-components-react/src/tooltip/tooltip.tsx
+++ b/packages/ui-components-react/src/tooltip/tooltip.tsx
@@ -1,8 +1,9 @@
 // Copyright 2024 IOTA Stiftung.
 // SPDX-License-Identifier: Apache-2.0.
-import { Tooltip as FlowbiteTooltip, Button as FlowbiteButton } from "flowbite-react";
+import { Tooltip as FlowbiteTooltip } from "flowbite-react";
 import React, { type ReactNode } from "react";
 import { TooltipPropTypes, type TooltipProps } from "./tooltipProps";
+import { Button } from "../button/button";
 
 /**
  * Tooltip component.
@@ -32,12 +33,10 @@ export class Tooltip extends React.Component<TooltipProps> {
 	 * @returns The component to render.
 	 */
 	public render(): ReactNode {
-		const { children, ...rest } = this._props;
+		const { children, color, ...rest } = this._props;
 		return (
 			<FlowbiteTooltip {...rest}>
-				<FlowbiteButton className="text-invert bg-surface-button hover:enabled:bg-surface-button-hover dark:bg-surface-button dark:hover:enabled:bg-surface-button-hover focus:ring-surface-button-pressed border-2 border-transparent focus:ring">
-					{children}
-				</FlowbiteButton>
+				<Button color={color ?? "primary"}>{children}</Button>
 			</FlowbiteTooltip>
 		);
 	}

--- a/packages/ui-components-react/src/tooltip/tooltipColors.ts
+++ b/packages/ui-components-react/src/tooltip/tooltipColors.ts
@@ -1,0 +1,53 @@
+// Copyright 2024 IOTA Stiftung.
+// SPDX-License-Identifier: Apache-2.0.
+
+/**
+ * Tooltip colors.
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const TooltipColors = {
+	/**
+	 * Primary color.
+	 */
+	Primary: "primary",
+
+	/**
+	 * Secondary color.
+	 */
+	Secondary: "secondary",
+
+	/**
+	 * Plain color.
+	 */
+	Plain: "plain",
+
+	/**
+	 * Error color.
+	 */
+	Error: "error",
+
+	/**
+	 * Warning color.
+	 */
+	Warning: "warning",
+
+	/**
+	 * Success color.
+	 */
+	Success: "success",
+
+	/**
+	 * Info color.
+	 */
+	Info: "info",
+
+	/**
+	 * Dark color.
+	 */
+	Dark: "dark"
+} as const;
+
+/**
+ * Tooltip colors.
+ */
+export type TooltipColor = (typeof TooltipColors)[keyof typeof TooltipColors];

--- a/packages/ui-components-react/src/tooltip/tooltipProps.ts
+++ b/packages/ui-components-react/src/tooltip/tooltipProps.ts
@@ -1,9 +1,10 @@
 // Copyright 2024 IOTA Stiftung.
 // SPDX-License-Identifier: Apache-2.0.
 import type { TooltipProps as FlowbiteTooltipProps } from "flowbite-react";
-import PropTypes, { type InferProps } from "prop-types";
+import PropTypes from "prop-types";
 import type { PropsWithChildren } from "react";
 import { TooltipAnimations } from "./tooltipAnimations";
+import { TooltipColors } from "./tooltipColors";
 import { TooltipPlacements } from "./tooltipPlacements";
 import { TooltipStyles } from "./tooltipStyles";
 import { TooltipTriggers } from "./tooltipTriggers";
@@ -13,6 +14,7 @@ export const TooltipPropTypes = {
 	animation: PropTypes.oneOf(Object.values(TooltipAnimations)),
 	placement: PropTypes.oneOf(Object.values(TooltipPlacements)),
 	trigger: PropTypes.oneOf(Object.values(TooltipTriggers)),
+	color: PropTypes.oneOf(Object.values(TooltipColors)),
 	arrow: PropTypes.bool,
 	content: PropTypes.string
 };
@@ -20,6 +22,13 @@ export const TooltipPropTypes = {
 /**
  * Tooltip props.
  */
-export type TooltipProps = PropsWithChildren<
-	InferProps<typeof TooltipPropTypes> & Omit<FlowbiteTooltipProps, "color" | "label">
->;
+export type TooltipProps = PropsWithChildren<{
+	style?: (typeof TooltipStyles)[keyof typeof TooltipStyles];
+	animation?: (typeof TooltipAnimations)[keyof typeof TooltipAnimations];
+	placement?: (typeof TooltipPlacements)[keyof typeof TooltipPlacements];
+	trigger?: (typeof TooltipTriggers)[keyof typeof TooltipTriggers];
+	color?: (typeof TooltipColors)[keyof typeof TooltipColors];
+	arrow?: boolean;
+	content?: string;
+}> &
+	Omit<FlowbiteTooltipProps, "color" | "label">;


### PR DESCRIPTION
# Replace Flowbite Button with Custom Button in Tooltip Component

Replace the Flowbite Button component with our own Button component in the Tooltip component to improve consistency with our design system and better control over component styling.

## Changes Made
- Replace `FlowbiteButton` with our custom [Button](cci:2://file:///Users/albertolive/Repos/iota/ui/packages/ui-components-react/src/button/button.tsx:38:0-108:1) component in tooltip.tsx
- Remove hardcoded button styles in favor of our Button component's built-in styling
- Add proper color prop handling with default to "primary"
- Create new `tooltipColors.ts` file with color definitions matching our Button colors
- Update [TooltipProps](cci:2://file:///Users/albertolive/Repos/iota/ui/packages/ui-components-react/src/tooltip/tooltipProps.ts:24:0-33:47) type definition to be more explicit and type-safe
- Remove unnecessary `InferProps` usage in favor of direct type definition

## Motivation
The Tooltip component was using Flowbite's Button component with custom styles, which created inconsistency with our design system and made maintenance more difficult. By using our own Button component, we ensure:
1. Consistent styling across all buttons in the application
2. Better type safety with our color system
3. Easier maintenance as we only need to update styles in one place

## Impact
- Improves visual consistency by using our design system's Button component
- Simplifies maintenance by centralizing button styling
- Enhances type safety with explicit prop types
- Makes the codebase more maintainable by reducing duplicate style definitions

## Breaking Changes
No breaking changes in this PR. The Tooltip component maintains the same API and functionality, only the internal implementation has changed.

## Testing Done
- Verified that all tooltip colors work correctly
- Confirmed that button styling matches our design system
- Checked that tooltip positioning and behavior remains unchanged
- Ensured type safety with the new TooltipProps definition