### PR TITLE
feat(accordion): add icons support to Accordion component

### DIFF
--- a/apps/ui-storybook-react/src/stories/Accordion.stories.ts
+++ b/apps/ui-storybook-react/src/stories/Accordion.stories.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0.
 import type { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
-import { Accordion } from "@twin.org/ui-components-react";
+import { Accordion, IconsSolid } from "@twin.org/ui-components-react";
 import { createElement } from "react";
 
 const meta = {
@@ -143,8 +143,8 @@ export const Default: Story = {
 
 export const AlwaysOpen: Story = {
 	args: {
-		children: [],
-		alwaysOpen: true
+		alwaysOpen: true,
+		children: []
 	}
 };
 
@@ -158,6 +158,53 @@ export const CollapseAll: Story = {
 export const Flush: Story = {
 	args: {
 		flush: true,
+		children: []
+	}
+};
+
+export const WithIcons: Story = {
+	args: {
+		items: [
+			{
+				title: "Accordion with Info Icon",
+				content: createElement(
+					"div",
+					null,
+					createElement(
+						"p",
+						{ className: "mb-2 text-gray-500 dark:text-gray-400" },
+						"This accordion item uses the InformationCircle icon from IconsSolid."
+					)
+				),
+				icon: IconsSolid.InboxFull
+			},
+			{
+				title: "Accordion with Question Icon",
+				content: createElement(
+					"div",
+					null,
+					createElement(
+						"p",
+						{ className: "mb-2 text-gray-500 dark:text-gray-400" },
+						"This accordion item uses the QuestionMarkCircle icon from IconsSolid."
+					)
+				),
+				icon: IconsSolid.QuestionCircle
+			},
+			{
+				title: "Accordion with Settings Icon",
+				content: createElement(
+					"div",
+					null,
+					createElement(
+						"p",
+						{ className: "mb-2 text-gray-500 dark:text-gray-400" },
+						"This accordion item uses the Cog icon from IconsSolid."
+					)
+				),
+				icon: IconsSolid.CalendarMonth
+			}
+		],
 		children: []
 	}
 };

--- a/packages/ui-components-react/src/accordion/accordion.tsx
+++ b/packages/ui-components-react/src/accordion/accordion.tsx
@@ -12,7 +12,16 @@ export const Accordion = memo(({ items, ...rest }: AccordionProps): JSX.Element 
 
 		return items.map((item, index) => (
 			<FlowbiteAccordion.Panel key={`accordion-panel-${index}`}>
-				<FlowbiteAccordion.Title>{item?.title}</FlowbiteAccordion.Title>
+				<FlowbiteAccordion.Title>
+					<div className="flex items-center">
+						{item?.icon && (
+							<span className="mr-2 inline-flex items-center">
+								<item.icon className="h-5 w-5" />
+							</span>
+						)}
+						{item?.title}
+					</div>
+				</FlowbiteAccordion.Title>
 				<FlowbiteAccordion.Content>{item?.content}</FlowbiteAccordion.Content>
 			</FlowbiteAccordion.Panel>
 		));

--- a/packages/ui-components-react/src/accordion/accordionProps.ts
+++ b/packages/ui-components-react/src/accordion/accordionProps.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0.
 import type { AccordionProps as FlowbiteAccordionProps } from "flowbite-react";
 import type { ReactNode } from "react";
+import type { IconComponent } from "../types/iconTypes";
 
 /**
  * Interface for accordion item structure
@@ -15,6 +16,10 @@ export interface AccordionItem {
 	 * The main content of the accordion item
 	 */
 	content?: ReactNode;
+	/**
+	 * Optional icon to display before the title
+	 */
+	icon?: IconComponent;
 }
 
 /**


### PR DESCRIPTION
# Add Icons Support to Accordion Component

This pull request introduces the ability to display icons alongside 
the titles in the Accordion component. This enhancement improves 
the visual representation and usability of the accordion items.

## Changes Made
- Modified the Accordion component to accept an optional icon 
  prop for each item.
- Updated the Accordion stories to include examples of items 
  with icons.
  - Added three example items with different icons: Info, 
    Question, and Settings.

## Motivation
The addition of icons enhances the user experience by providing 
visual cues that help users quickly identify the purpose of each 
accordion item.

## Impact
- Improves the visual appeal of the Accordion component.
- Changes how accordion items are rendered, now including icons.
- Benefits users by making the accordion content more intuitive.

## Breaking Changes
- No breaking changes in this PR.

## Testing Done
- Verified that the Accordion component renders correctly with 
  and without icons.
- Tested all new stories in Storybook to ensure proper display 
  of icons.