### PR TITLE
chore(ui-components): update build configuration to decrease bundle size

### DIFF
--- a/packages/ui-components-react/package.json
+++ b/packages/ui-components-react/package.json
@@ -22,11 +22,12 @@
 		"bundle:cjs": "rollup --config rollup.config.mjs --environment MODULE:cjs",
 		"bundle": "npm run bundle:esm && npm run bundle:cjs",
 		"dist": "npm run clean && npm run build && npm run bundle",
-		"dev:watch": "concurrently \"npm run build -- --watch\" \"nodemon --watch dist/es --exec \\\"npm run bundle\\\"\"",
+		"dev:watch": "concurrently \"npm run build -- --watch\" \"nodemon --ignore dist/ --watch src/ --exec \\\"npm run bundle\\\"\"",
 		"dev": "npm run clean && npm run build && npm run dev:watch",
 		"dist:no-test": "npm run clean && npm run build && npm run bundle",
 		"lint": "eslint .",
-		"lint:fix": "eslint . --fix"
+		"lint:fix": "eslint . --fix",
+		"postbundle": "node scripts/copy-compatibility.js"
 	},
 	"dependencies": {
 		"@twin.org/ui-tailwind": "0.0.1-next.35",

--- a/packages/ui-components-react/rollup.config.mjs
+++ b/packages/ui-components-react/rollup.config.mjs
@@ -106,31 +106,17 @@ const mainBundle = {
 	...baseConfig,
 	input: './dist/es/index.js',
 	output: isEsm
-		? [
-				{
-					format,
-					name: 'TwinUIComponents',
-					exports: 'named',
-					globals,
-					sourcemap: true,
-					preserveModules: true,
-					preserveModulesRoot: 'dist/es',
-					dir: `dist/${format}`,
-					entryFileNames: '[name].mjs'
-				},
-				// Add backward compatibility output to esm directory for existing imports
-				{
-					format,
-					name: 'TwinUIComponents',
-					exports: 'named',
-					globals,
-					sourcemap: true,
-					preserveModules: true,
-					preserveModulesRoot: 'dist/es',
-					dir: 'dist/esm',
-					entryFileNames: '[name].mjs'
-				}
-			]
+		? {
+				format,
+				name: 'TwinUIComponents',
+				exports: 'named',
+				globals,
+				sourcemap: true,
+				preserveModules: true,
+				preserveModulesRoot: 'dist/es',
+				dir: `dist/${format}`,
+				entryFileNames: '[name].mjs'
+		  }
 		: {
 				file: `dist/${format}/index.${extension}`,
 				format,
@@ -138,31 +124,12 @@ const mainBundle = {
 				exports: 'named',
 				globals,
 				sourcemap: true
-			}
+		  },
+    // Prevent watching the output directory to avoid infinite build loops
+    watch: {
+        exclude: ['dist/**', 'node_modules/**']
+    }
 };
 
-// Only use this when you want to build individual components as well
-// const createIndividualComponentConfigs = () => {
-//   const componentEntryPoints = glob.sync('./dist/es/*/index.js');
-//
-//   return componentEntryPoints.map(input => {
-//     const componentName = path.basename(path.dirname(input));
-//     return {
-//       ...baseConfig,
-//       input,
-//       output: {
-//         file: `dist/${format}/${componentName}.${extension}`,
-//         format,
-//         name: `TwinUIComponents${componentName.charAt(0).toUpperCase() + componentName.slice(1)}`,
-//         exports: 'named',
-//         globals,
-//         sourcemap: true
-//       }
-//     };
-//   });
-// };
-
-// Export only the main bundle configuration for now
-// If you want to build individual components as well, uncomment this:
-// export default [mainBundle, ...createIndividualComponentConfigs()];
+// Export only the main bundle configuration
 export default mainBundle;

--- a/packages/ui-components-react/rollup.config.mjs
+++ b/packages/ui-components-react/rollup.config.mjs
@@ -116,7 +116,7 @@ const mainBundle = {
 				preserveModulesRoot: 'dist/es',
 				dir: `dist/${format}`,
 				entryFileNames: '[name].mjs'
-		  }
+			}
 		: {
 				file: `dist/${format}/index.${extension}`,
 				format,
@@ -124,11 +124,11 @@ const mainBundle = {
 				exports: 'named',
 				globals,
 				sourcemap: true
-		  },
-    // Prevent watching the output directory to avoid infinite build loops
-    watch: {
-        exclude: ['dist/**', 'node_modules/**']
-    }
+			},
+	// Prevent watching the output directory to avoid infinite build loops
+	watch: {
+		exclude: ['dist/**', 'node_modules/**']
+	}
 };
 
 // Export only the main bundle configuration

--- a/packages/ui-components-react/scripts/copy-compatibility.js
+++ b/packages/ui-components-react/scripts/copy-compatibility.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Copyright 2024 IOTA Stiftung.
+// SPDX-License-Identifier: Apache-2.0.
+
+/**
+ * This script creates copies of files from the ES module directory to the ESM directory
+ * for backward compatibility with Storybook and other consumers that might still use the old path.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { glob } from 'glob';
+
+// Get __dirname equivalent in ESM
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Configuration
+const ROOT_DIR = path.resolve(__dirname, '..');
+const ES_DIR = path.resolve(ROOT_DIR, 'dist/es');
+const ESM_DIR = path.resolve(ROOT_DIR, 'dist/esm');
+
+/**
+ * Creates a compatibility layer between the `es/` and `esm/` directories.
+ * This ensures backward compatibility with tools like Storybook.
+ */
+async function createCompatibilityLayer() {
+	// eslint-disable-next-line no-console
+	console.log('Creating compatibility layer for Storybook...');
+
+	// Ensure ESM directory exists
+	if (!fs.existsSync(ESM_DIR)) {
+		fs.mkdirSync(ESM_DIR, { recursive: true });
+	}
+
+	try {
+		// Find all .mjs files in the ES directory
+		const files = await glob('**/*.mjs', { cwd: ES_DIR });
+
+		if (files.length === 0) {
+			// eslint-disable-next-line no-console
+			console.log('No .mjs files found in ES directory. Check your build process.');
+			return;
+		}
+
+		// eslint-disable-next-line no-console
+		console.log(`Found ${files.length} files to copy for compatibility...`);
+
+		// Copy each file from ES to ESM
+		for (const file of files) {
+			const sourceFile = path.join(ES_DIR, file);
+			const targetFile = path.join(ESM_DIR, file);
+			const targetDir = path.dirname(targetFile);
+
+			// Ensure the target directory exists
+			if (!fs.existsSync(targetDir)) {
+				fs.mkdirSync(targetDir, { recursive: true });
+			}
+
+			// Copy the file
+			fs.copyFileSync(sourceFile, targetFile);
+		}
+
+		// Also copy map files if they exist
+		const mapFiles = await glob('**/*.mjs.map', { cwd: ES_DIR });
+		for (const file of mapFiles) {
+			const sourceFile = path.join(ES_DIR, file);
+			const targetFile = path.join(ESM_DIR, file);
+			const targetDir = path.dirname(targetFile);
+
+			// Ensure the target directory exists
+			if (!fs.existsSync(targetDir)) {
+				fs.mkdirSync(targetDir, { recursive: true });
+			}
+
+			// Copy the file
+			fs.copyFileSync(sourceFile, targetFile);
+		}
+
+		// eslint-disable-next-line no-console
+		console.log(`✅ Successfully copied ${files.length} files to ESM directory for compatibility`);
+	} catch (error) {
+		// eslint-disable-next-line no-console
+		console.error(`❌ Error creating compatibility layer: ${error.message}`);
+		process.exit(1);
+	}
+}
+
+// Run the script
+createCompatibilityLayer();


### PR DESCRIPTION
# Update Build Configuration for UI Components

This PR improves the build process for the UI Components package by optimizing the development workflow and build configuration to reduce bundle size.

## Changes Made
- Modified `dev:watch` script to:
  - Ignore changes in `dist/` directory
  - Watch `src/` directory instead of `dist/es/`
- Simplified Rollup ESM output configuration:
  - Removed duplicate ESM output
  - Consolidated single ESM output configuration
- Added `postbundle` script to handle compatibility files
- Added watch exclusions in Rollup config to prevent infinite build loops

## Motivation
These changes were necessary to:
- Prevent infinite build loops during development
- Improve build performance by reducing redundant operations
- Maintain backward compatibility with existing imports
- Streamline the build configuration
- Reduce bundle size

## Impact
- Improves developer experience by preventing infinite build loops
- Reduces build times by eliminating redundant operations
- Maintains compatibility with existing import paths
- Benefits developers working on the UI Components package
- Reduce bundle size

## Breaking Changes
No breaking changes in this PR

## Testing Done
- Verified build process works correctly with `npm run dev`
- Tested watch mode to ensure no infinite loops occur
- Confirmed ESM output matches expected format
- Verified compatibility files are copied correctly