### PR TITLE
chore: exclude changelog.md files for prettier and cspell

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 package-lock.json
 .svelte-kit
+changelog.md
 **/docs/reference
 **/docs/open-api
 **/static/locales

--- a/cspell.json
+++ b/cspell.json
@@ -3,6 +3,7 @@
 	"ignorePaths": [
 		"**/node_modules/**",
 		"LICENSE",
+		"changelog.md",
 		"**/coverage/**",
 		"**/dist/**",
 		"**/docs/reference/**",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"lint:fix": "prettier --config .prettierrc --write .",
 		"lint:code": "eslint . --ext .js,.mjs,.ts,.tsx,.svelte",
 		"lint:markdown": "markdownlint **/*.md --ignore **/node_modules/** --ignore **/docs/reference/**",
-		"lint:spell": "cspell ** --no-progress --exclude changelog.md",
+		"lint:spell": "cspell ** --no-progress",
 		"lint": "npm run lint:format && npm run lint:code && npm run lint:markdown && npm run lint:spell",
 		"local-link": "node ./scripts/local-link.mjs",
 		"commitlint": "commitlint --edit",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"lint:fix": "prettier --config .prettierrc --write .",
 		"lint:code": "eslint . --ext .js,.mjs,.ts,.tsx,.svelte",
 		"lint:markdown": "markdownlint **/*.md --ignore **/node_modules/** --ignore **/docs/reference/**",
-		"lint:spell": "cspell ** --no-progress",
+		"lint:spell": "cspell ** --no-progress --exclude changelog.md",
 		"lint": "npm run lint:format && npm run lint:code && npm run lint:markdown && npm run lint:spell",
 		"local-link": "node ./scripts/local-link.mjs",
 		"commitlint": "commitlint --edit",


### PR DESCRIPTION
Now this returns no errors
```
cd ui
npm run lint
```

<details><summary>output</summary>
<p>

```
❯ npm run lint

> @twin.org/ui@0.0.0 lint
> npm run lint:format && npm run lint:code && npm run lint:markdown && npm run lint:spell


> @twin.org/ui@0.0.0 lint:format
> prettier --config .prettierrc --check .

Checking formatting...
All matched files use Prettier code style!

> @twin.org/ui@0.0.0 lint:code
> eslint . --ext .js,.mjs,.ts,.tsx,.svelte

=============

WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=4.7.4 <5.6.0

YOUR TYPESCRIPT VERSION: 5.8.3

Please only submit bug reports when using the officially supported version.

=============

> @twin.org/ui@0.0.0 lint:markdown
> markdownlint **/*.md --ignore **/node_modules/** --ignore **/docs/reference/**


> @twin.org/ui@0.0.0 lint:spell
> cspell ** --no-progress --exclude changelog.md

CSpell: Files checked: 340, Issues found: 0 in 0 files.
```

I tried fixing the eslint warning, but took too long so I left it there

</p>
</details> 