### PR TITLE
feat: pass all props for Modal footerButtons array 

### DIFF
--- a/packages/ui-components-react/src/modal/modal.tsx
+++ b/packages/ui-components-react/src/modal/modal.tsx
@@ -22,17 +22,21 @@ export const Modal = memo(
 				{body && <FlowbiteModal.Body>{body}</FlowbiteModal.Body>}
 				{footerButtons && footerButtons.length > 0 && (
 					<FlowbiteModal.Footer>
-						{footerButtons.map((button, index) => (
-							<Button
-								key={`modal-button-${index}`}
-								color={button?.variant ?? "primary"}
-								onClick={() => handleButtonClick(button?.onClick)}
-								buttonText={button?.label}
-								showButtonText
-							>
-								{button?.label}
-							</Button>
-						))}
+						{footerButtons.map((button, index) => {
+							const { onClick, variant, label, ...buttonProps } = button;
+							return (
+								<Button
+									key={`modal-button-${index}`}
+									color={variant ?? "primary"}
+									onClick={() => handleButtonClick(onClick)}
+									buttonText={label}
+									showButtonText
+									{...buttonProps}
+								>
+									{label}
+								</Button>
+							);
+						})}
 					</FlowbiteModal.Footer>
 				)}
 			</FlowbiteModal>


### PR DESCRIPTION
Pass all props for Modal footerButtons array to be able to pass`data-testid` to the buttons.

This should now work in `app/[locale]/(protected)/profile/credentials/add-new-credential/multi-steps/request-signed-credential/steps/CredentialLibraryStep.tsx` in the `indentity-mvp` project

```tsx
<Modal
    size="lg"
    show={!!selectedTemplate && isModalShown}
    key={`${selectedTemplate}`}
    onClose={() => setSelectedTemplate(null)}
    header="Document Preview"
    body={<CredentialDetailsModalBody credential={selectedTemplate} />}
    footerButtons={[
        {
            label: 'Request this credential',
            onClick: () => onRequestCredential(selectedTemplate),
            'data-testid': 'button-request-credential', // <-- THIS works (though with a TS error)
        },
    ]}
/>
```