### PR TITLE
feat: add all ButtonProps to Modal footerButtons array prop

### DIFF
--- a/packages/ui-components-react/src/modal/modalProps.ts
+++ b/packages/ui-components-react/src/modal/modalProps.ts
@@ -7,11 +7,12 @@ import type { ModalPosition } from "./modalPositions";
 import { ModalSizes } from "./modalSizes";
 import type { ModalSize } from "./modalSizes";
 import type { ButtonColor } from "../button/buttonColors";
+import type { ButtonProps } from "../button/buttonProps";
 
 /**
  *
  */
-export interface FooterButton {
+export interface FooterButton extends ButtonProps {
 	/**
 	 * The text to display on the button.
 	 * This will be rendered as the button's content.

--- a/release/README.md
+++ b/release/README.md
@@ -18,4 +18,3 @@ return new PrereleasePatchVersionUpdate(this.prereleaseType);
 ```shell
 npx patch-package release-please --patch-dir release
 ```
-


### PR DESCRIPTION
Small PR to be able to add the `outline` prop in the Modal `footerButtons`

<img width="845" alt="image" src="https://github.com/user-attachments/assets/6db6e91b-8548-4bd5-82e1-78e0faadf4e5" />
